### PR TITLE
비동기 호출 시 spanId, traceId가 전파되지 않는 버그 픽스

### DIFF
--- a/apps/user-service/build.gradle
+++ b/apps/user-service/build.gradle
@@ -63,6 +63,7 @@ dependencies {
 	implementation "io.micrometer:micrometer-tracing"
 	implementation 'io.micrometer:micrometer-registry-prometheus'
 	implementation "org.springframework.boot:spring-boot-starter-actuator"
+	implementation "io.micrometer:context-propagation"
 
 	// Lombok
 	compileOnly 'org.projectlombok:lombok:1.18.30'

--- a/apps/user-service/src/main/java/site/icebang/domain/workflow/controller/WorkflowController.java
+++ b/apps/user-service/src/main/java/site/icebang/domain/workflow/controller/WorkflowController.java
@@ -1,7 +1,5 @@
 package site.icebang.domain.workflow.controller;
 
-import java.util.concurrent.CompletableFuture;
-
 import org.springframework.http.ResponseEntity;
 import org.springframework.web.bind.annotation.*;
 
@@ -31,7 +29,7 @@ public class WorkflowController {
   @PostMapping("/{workflowId}/run")
   public ResponseEntity<Void> runWorkflow(@PathVariable Long workflowId) {
     // HTTP 요청/응답 스레드를 블로킹하지 않도록 비동기 실행
-    CompletableFuture.runAsync(() -> workflowExecutionService.executeWorkflow(workflowId));
+    workflowExecutionService.executeWorkflow(workflowId);
     return ResponseEntity.accepted().build();
   }
 }

--- a/apps/user-service/src/main/java/site/icebang/domain/workflow/service/WorkflowExecutionService.java
+++ b/apps/user-service/src/main/java/site/icebang/domain/workflow/service/WorkflowExecutionService.java
@@ -5,6 +5,7 @@ import java.util.List;
 import java.util.Map;
 import java.util.stream.Collectors;
 
+import org.springframework.scheduling.annotation.Async;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
 
@@ -43,6 +44,7 @@ public class WorkflowExecutionService {
   private final List<TaskBodyBuilder> bodyBuilders;
 
   @Transactional
+  @Async("traceExecutor")
   public void executeWorkflow(Long workflowId) {
     log.info("========== 워크플로우 실행 시작: WorkflowId={} ==========", workflowId);
     WorkflowRun workflowRun = WorkflowRun.start(workflowId);

--- a/apps/user-service/src/main/java/site/icebang/global/config/asnyc/AsyncConfig.java
+++ b/apps/user-service/src/main/java/site/icebang/global/config/asnyc/AsyncConfig.java
@@ -1,0 +1,24 @@
+package site.icebang.global.config.asnyc;
+
+import org.springframework.context.annotation.Bean;
+import org.springframework.context.annotation.Configuration;
+import org.springframework.core.task.support.ContextPropagatingTaskDecorator;
+import org.springframework.scheduling.annotation.EnableAsync;
+import org.springframework.scheduling.concurrent.ThreadPoolTaskExecutor;
+
+@Configuration
+@EnableAsync
+public class AsyncConfig {
+
+  @Bean("traceExecutor")
+  public ThreadPoolTaskExecutor traceExecutor() {
+    ThreadPoolTaskExecutor executor = new ThreadPoolTaskExecutor();
+    executor.setCorePoolSize(10);
+    executor.setMaxPoolSize(50);
+    executor.setQueueCapacity(100);
+    executor.setTaskDecorator(new ContextPropagatingTaskDecorator()); // 필수
+    executor.setThreadNamePrefix("trace-");
+    executor.initialize();
+    return executor;
+  }
+}


### PR DESCRIPTION
Computable 클래스 직접 호출이 아닌 `@Async` 어노테이션 사용

<!-- 
PR 제목 작성 가이드:
형식: <타입>: <간단한 설명>
타입 예시:
- feat: 새로운 기능 추가
- fix: 버그 수정
- docs: 문서 수정
- style: 코드 포맷팅
- refactor: 코드 리팩토링
- test: 테스트 추가/수정
- chore: 빌드, 패키지 등 기타 작업
예시: feat: 사용자 로그인 API 구현
-->

## 📝 작업 내용
<!-- 이번 PR에서 구현한 기능이나 수정한 내용을 구체적으로 작성해주세요 -->
- Computable 클래스 직접 호출이 아닌 `@Async` 어노테이션 사용
- micrometer 라이브러리를 통해 spanId, traceId 자동 전파
---

## 🔗 관련 이슈
<!-- 관련된 이슈가 있다면 아래 형식으로 작성해주세요 -->
- Closes #이슈번호
- Related to #이슈번호

---

## 💬 추가 요청사항
<!-- 리뷰어에게 특별히 확인받고 싶은 부분이나 질문이 있다면 작성해주세요 -->

---

## ✅ 체크리스트

### 코드 품질
- [ ] 커밋 컨벤션 준수 (feat/fix/docs/refactor 등)
- [ ] 불필요한 코드/주석 제거

### 테스트
- [ ] 로컬 환경에서 동작 확인 완료
- [ ] 기존 기능에 영향 없음 확인

### 배포 준비
- [ ] 환경변수 추가/변경사항 문서화
- [ ] DB 마이그레이션 필요 여부 확인
- [ ] 배포 시 주의사항 없음
